### PR TITLE
enum34 only where it's needed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-enum34>=1.1.6
+enum34>=1.1.6;python_version<3.4
 six>=1.11.0
 requests>=2.10.0
 semantic-version>=2.6.0


### PR DESCRIPTION
In some configurations installing enum34 into a newer Python can break stdlib packages as it may mask the stdlib enum module