### PR TITLE
Update README.md

### DIFF
--- a/etcd3/swaggerdefs/README.md
+++ b/etcd3/swaggerdefs/README.md
@@ -1,6 +1,6 @@
 This directory contains the swagger spec of versioned etcd GRPC-Gateway apis
 
-Files are generated from etcd source using script [genrate_proto_defs.py](../../scripts/genrate_proto_defs.py)
+Files are generated from etcd source using script [generate_proto_defs.py](../../scripts/generate_proto_defs.py)
 
 DO NOT EDIT!
 


### PR DESCRIPTION
Fix typo (missing 'e' in 'generate')