### PR TITLE
add 'unEvent' to remove a (python) filter/callback from the Watcher

### DIFF
--- a/etcd3/stateful/watch.py
+++ b/etcd3/stateful/watch.py
@@ -240,6 +240,24 @@ class Watcher(object):
             raise TypeError('callback should be a callable')
         self.callbacks.append((self.get_filter(filter), filter, cb))
 
+    @check_param(at_least_one_of=['filter', 'cb'])
+    def unEvent(self, filter=None, cb=None):
+        """
+        remove a callback or filter event that's been previously added via onEvent()
+        If both parameters are given they are ANDd together; to OR the, make two calls.
+
+        :type filter: callable or regex string or EventType
+        :param filter: the callable filter or regex string or EventType the event to be removed was registerd with
+        :param cb: the callback funtion the event to be removed was registerd with
+        """
+        for i in reversed(range(len(self.callbacks))):
+            efilter, eraw_filter, ecb = self.callbacks[i]
+            if cb is not None and  ecb != cb:
+                    continue
+            if filter is not None and filter not in (efilter, eraw_filter):
+                    continue
+            del self.callbacks[i]
+
     def dispatch_event(self, event):
         """
         Find the callbacks, if callback's filter fits this event, call the callback

--- a/etcd3/stateful/watch.py
+++ b/etcd3/stateful/watch.py
@@ -241,7 +241,7 @@ class Watcher(object):
         self.callbacks.append((self.get_filter(filter), filter, cb))
 
     @check_param(at_least_one_of=['filter', 'cb'])
-    def unEvent(self, filter=None, cb=None):
+    def unEvent(self, filter=None, cb=None): # noqa # ignore redefinition of filter
         """
         remove a callback or filter event that's been previously added via onEvent()
         If both parameters are given they are ANDd together; to OR the, make two calls.

--- a/tests/test_watch_util.py
+++ b/tests/test_watch_util.py
@@ -211,7 +211,7 @@ def test_watcher_update_callbacks(client):
 
     etcdctl('put fizz buzz')
 
-    while len(all_list) < 9:
+    while len(all_list) < 10:
         time.sleep(0.2)
 
     assert len(fizz_list) == 9


### PR DESCRIPTION
allow for removal of filters/callbacks from the Watcher