### PR TITLE
lazy aiohttp client creation

### DIFF
--- a/etcd3/aio_client.py
+++ b/etcd3/aio_client.py
@@ -16,7 +16,7 @@ from .baseclient import DEFAULT_VERSION
 from .errors import Etcd3Exception
 from .errors import Etcd3StreamError
 from .errors import get_client_error
-from .utils import iter_json_string, Etcd3Warning
+from .utils import iter_json_string, Etcd3Warning, cached_property
 
 
 class ModelizedResponse(object):
@@ -174,8 +174,11 @@ class AioClient(BaseClient):
             ssl_context.verify_mode = cert_reqs
             ssl_context.load_verify_locations(cafile=cafile)
             ssl_context.load_cert_chain(*self.cert)
-        connector = aiohttp.TCPConnector(limit=pool_size, ssl=self.ssl_context)
-        self.session = aiohttp.ClientSession(connector=connector)
+
+    @cached_property
+    def session(self):
+        connector = aiohttp.TCPConnector(limit=self.pool_size, ssl=self.ssl_context)
+        return aiohttp.ClientSession(connector=connector)
 
     async def close(self):
         """

--- a/etcd3/baseclient.py
+++ b/etcd3/baseclient.py
@@ -66,6 +66,7 @@ class BaseClient(AuthAPI, ClusterAPI, KVAPI, LeaseAPI, MaintenanceAPI,
         if not user_agent:
             self.user_agent = 'etcd3-py/' + __version__
         self.timeout = timeout
+        self.pool_size = pool_size
         self.headers = headers or {}
         self.username = username
         self.password = password

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,4 +22,3 @@ test = pytest
 
 [metadata]
 license_file = LICENSE
-


### PR DESCRIPTION
fix #114 

Only happens when aiohttp>=4.0 (currently 4.0.0a1)
Only happens when you init a AioClient before eventloop runs. (run the example in readme)

Very narrow case, not test needed. 

No need to release a new version for that.